### PR TITLE
add: bank sets to ShowFile_v0.xsd

### DIFF
--- a/FormatSchemes/ProjectFile/ShowFile_v0.xsd
+++ b/FormatSchemes/ProjectFile/ShowFile_v0.xsd
@@ -11,6 +11,11 @@
     			</annotation>
             </element>
             <element name="uihint" type="tns:KeyValuePair" maxOccurs="unbounded" minOccurs="0"></element>
+            <element name="banksets" type="tns:BankSet" maxOccurs="unbounded" minOccurs="0">
+		    <annotation>
+			    <documentation>This field defines the non temporary bank sets</documentation>
+		    </annotation>
+	    </element>
     	</sequence>
     	<attribute name="show_name" type="string">
     		<annotation>
@@ -96,6 +101,48 @@ They can be used to implement UI controls on the touch screens besides scene swi
     		</annotation>
         </attribute>
     </complexType>
+
+<complexType name="BankSet">
+	<annotation>
+		<documentation>
+			A bank set that should be available with the show file. This won't be loaded by fish but needs to be managed by the
+			GUI as the GUI will also manage additional temporary bank sets.
+		</documentation>
+	</annotation>
+	<attribute name="linked_by_default" type="bool" use="optional">
+		<annotation>
+			<documentation>If this attribute is obmitted or set to true, the bank set will be linked with fish by default.</documentation>
+		</annotation>
+	</attribute>
+	<sequence>
+		<element name="bank" maxOccurs="unbounded">
+			<complexType>
+				<sequence>
+					<element name="hslcolumn" maxOccurs="unbounded" minOccurs="0">
+						<complexType>
+							<attribute name="display_name" type="string" use="required"></attribute>
+							<attribute name="top_line_inverted" type="bool" use="optional"></attribute>
+							<attribute name="bottom_line_inverted" type="bool" use="optional"></attribute>
+							<attribute name="lcd_color" type="string" use="optional"><!-- TODO use choice type--></attribute>
+							<attribute name="color" type="string" use="required"><!-- TODO introduce format regex for syntax check--></attributw>
+						</complexType>
+					</element>
+					<element name="rawcolumn" maxOccurs="unbounded" minOccurs="0">
+						<complexType>
+							<attribute name="display_name" type="string" use="required"></attribute>
+							<attribute name="secondary_text_line" type="string" use="required"></attribute>
+							<attribute name="top_line_inverted" type="bool" use="optional"></attribute>
+							<attribute name="bottom_line_inverted" type="bool" use="optional"></attribute>
+							<attribute name="lcd_color" type="string" use="optional"><!-- TODO use choice type--></attribute>
+							<attribute name="fader_position" type="int" use="required"><!-- TODO use simple type with minInclusive and maxInclusive --></attribute>
+							<attribute name="encoder_position" type="int" use="required"><!-- TODO use simple type with minInclusive and maxInclusive --></attribute>
+						</complexType>
+					</element>
+				</secuence>
+			</complexType>
+		</element>
+	</sequence>
+</complexType>
 
     <complexType name="ChannelLink">
         <annotation>

--- a/FormatSchemes/ProjectFile/ShowFile_v0.xsd
+++ b/FormatSchemes/ProjectFile/ShowFile_v0.xsd
@@ -109,7 +109,7 @@ They can be used to implement UI controls on the touch screens besides scene swi
 			GUI as the GUI will also manage additional temporary bank sets.
 		</documentation>
 	</annotation>
-	<attribute name="linked_by_default" type="bool" use="optional">
+	<attribute name="linked_by_default" type="boolean" use="optional">
 		<annotation>
 			<documentation>If this attribute is obmitted or set to true, the bank set will be linked with fish by default.</documentation>
 		</annotation>
@@ -121,8 +121,8 @@ They can be used to implement UI controls on the touch screens besides scene swi
 					<element name="hslcolumn" maxOccurs="unbounded" minOccurs="0">
 						<complexType>
 							<attribute name="display_name" type="string" use="required"></attribute>
-							<attribute name="top_line_inverted" type="bool" use="optional"></attribute>
-							<attribute name="bottom_line_inverted" type="bool" use="optional"></attribute>
+							<attribute name="top_line_inverted" type="boolean" use="optional"></attribute>
+							<attribute name="bottom_line_inverted" type="boolean" use="optional"></attribute>
 							<attribute name="lcd_color" type="string" use="optional"><!-- TODO use choice type--></attribute>
 							<attribute name="color" type="string" use="required"><!-- TODO introduce format regex for syntax check--></attribute>
 						</complexType>
@@ -131,8 +131,8 @@ They can be used to implement UI controls on the touch screens besides scene swi
 						<complexType>
 							<attribute name="display_name" type="string" use="required"></attribute>
 							<attribute name="secondary_text_line" type="string" use="required"></attribute>
-							<attribute name="top_line_inverted" type="bool" use="optional"></attribute>
-							<attribute name="bottom_line_inverted" type="bool" use="optional"></attribute>
+							<attribute name="top_line_inverted" type="boolean" use="optional"></attribute>
+							<attribute name="bottom_line_inverted" type="boolean" use="optional"></attribute>
 							<attribute name="lcd_color" type="string" use="optional"><!-- TODO use choice type--></attribute>
 							<attribute name="fader_position" type="int" use="required"><!-- TODO use simple type with minInclusive and maxInclusive --></attribute>
 							<attribute name="encoder_position" type="int" use="required"><!-- TODO use simple type with minInclusive and maxInclusive --></attribute>

--- a/FormatSchemes/ProjectFile/ShowFile_v0.xsd
+++ b/FormatSchemes/ProjectFile/ShowFile_v0.xsd
@@ -124,7 +124,7 @@ They can be used to implement UI controls on the touch screens besides scene swi
 							<attribute name="top_line_inverted" type="bool" use="optional"></attribute>
 							<attribute name="bottom_line_inverted" type="bool" use="optional"></attribute>
 							<attribute name="lcd_color" type="string" use="optional"><!-- TODO use choice type--></attribute>
-							<attribute name="color" type="string" use="required"><!-- TODO introduce format regex for syntax check--></attributw>
+							<attribute name="color" type="string" use="required"><!-- TODO introduce format regex for syntax check--></attribute>
 						</complexType>
 					</element>
 					<element name="rawcolumn" maxOccurs="unbounded" minOccurs="0">
@@ -138,7 +138,7 @@ They can be used to implement UI controls on the touch screens besides scene swi
 							<attribute name="encoder_position" type="int" use="required"><!-- TODO use simple type with minInclusive and maxInclusive --></attribute>
 						</complexType>
 					</element>
-				</secuence>
+				</sequence>
 			</complexType>
 		</element>
 	</sequence>

--- a/FormatSchemes/ProjectFile/ShowFile_v0.xsd
+++ b/FormatSchemes/ProjectFile/ShowFile_v0.xsd
@@ -143,17 +143,6 @@
     </complexType>
 
 <complexType name="BankSet">
-	<annotation>
-		<documentation>
-			A bank set that should be available with the show file. This won't be loaded by fish but needs to be managed by the
-			GUI as the GUI will also manage additional temporary bank sets.
-		</documentation>
-	</annotation>
-	<attribute name="linked_by_default" type="boolean" use="optional">
-		<annotation>
-			<documentation>If this attribute is obmitted or set to true, the bank set will be linked with fish by default.</documentation>
-		</annotation>
-	</attribute>
 	<sequence>
 		<element name="bank" maxOccurs="unbounded">
 			<complexType>
@@ -182,6 +171,17 @@
 			</complexType>
 		</element>
 	</sequence>
+	<annotation>
+		<documentation>
+			A bank set that should be available with the show file. This won't be loaded by fish but needs to be managed by the
+			GUI as the GUI will also manage additional temporary bank sets.
+		</documentation>
+	</annotation>
+	<attribute name="linked_by_default" type="boolean" use="optional">
+		<annotation>
+			<documentation>If this attribute is obmitted or set to true, the bank set will be linked with fish by default.</documentation>
+		</annotation>
+	</attribute>
 </complexType>
 
     <complexType name="ChannelLink">


### PR DESCRIPTION
Introducing a data type enabling us to store bank sets that should be loaded with the show. This is required to not have to manually set up the bank sets after every load.