### PR TITLE
add: macro support to ShowFile_v0.xsd

### DIFF
--- a/FormatSchemes/ProjectFile/ShowFile_v0.xsd
+++ b/FormatSchemes/ProjectFile/ShowFile_v0.xsd
@@ -511,8 +511,15 @@
         <annotation><documentation>Macro is a set of CLI commands that will be executed on actions occuring in the editor. While they may be triggered on keypad updated from fish, they are not triggered on fish events, as they are only transferred for debugging purposes.</documentation></annotation>
         <element name="content" type="string"><annotation><documentation>The commands of the macro</documentation></annotation></element>
         <sequence>
-            <element name="trigger" minOccurs="0" maxOccurs="unbounded" type="tns:KeyValuePair">
-                <annotation><documentation>Keys indicate the configured trigger and the values indicate if they're temporarily disabled or not.</documentation></annotation>
+            <element name="trigger" minOccurs="0" maxOccurs="unbounded">
+                <complexType>
+                    <sequence>
+                        <element name="configuration" minOccurs="0" maxOccurs="unbounded" type="tns:KeyValuePair"></element>
+                    </sequence>
+                    <attribute name="name" type="string"></attribute>
+                    <attribute name="type" type="string"></attribute>
+                    <attribute name="enabled" type="boolean"></attribute>
+                </complexType>
             </element>
         </sequence>
         <attribute name="name" type="string"><annotation><documentation>Human readable, non-unique name</documentation></annotation></attribute>

--- a/FormatSchemes/ProjectFile/ShowFile_v0.xsd
+++ b/FormatSchemes/ProjectFile/ShowFile_v0.xsd
@@ -21,6 +21,7 @@
               </annotation>
             </element>
             <element name="eventsource" type="tns:EventSourceConfig" maxOccurs="unbounded" minOccurs="0"></element>
+            <element name="macro" type="tns:Macro" maxOccurs="unbounded" minOccurs="0"></element>
         </choice>
         <attribute name="show_name" type="string">
             <annotation>
@@ -506,5 +507,16 @@
 	<attribute name="name" type="string"></attribute>
     </complexType>
 
+    <complexType name="Macro">
+        <annotation><documentation>Macro is a set of CLI commands that will be executed on actions occuring in the editor. While they may be triggered on keypad updated from fish, they are not triggered on fish events, as they are only transferred for debugging purposes.</documentation></annotation>
+        <element name="content" type="string"><annotation><documentation>The commands of the macro</documentation></annotation></element>
+        <sequence>
+            <element name="trigger" minOccurs="0" maxOccurs="unbounded" type="tns:KeyValuePair">
+                <annotation><documentation>Keys indicate the configured trigger and the values indicate if they're temporarily disabled or not.</documentation></annotation>
+            </element>
+        </sequence>
+        <attribute name="name" type="string"><annotation><documentation>Human readable, non-unique name</documentation></annotation></attribute>
+    </complexType>
+    
     <element name="bord_configuration" type="tns:BordConfiguration"></element>
 </schema>


### PR DESCRIPTION
TBD:
 * Do we want further properties in a macro?
 * What is a good way to describe triggers? So far I only have keypad inputs and the apply button from fish (as well as manual invocation using the GUI or CLI) in mind. Are the further useful triggers that the user should be able to configure?